### PR TITLE
Add Swift Testing-based unit tests

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,5 +11,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: '6.0'
       - name: Run unit tests
         run: swift test --package-path TicTacToeCore

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,15 @@
+name: TicTacToeCore Tests
+
+on:
+  pull_request:
+    paths:
+      - 'TicTacToeCore/**'
+      - '.github/workflows/**'
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run unit tests
+        run: swift test --package-path TicTacToeCore

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -8,11 +8,14 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-14 # Xcode 16.x が利用できる macOS 14 を指定
     steps:
       - uses: actions/checkout@v3
-      - uses: swift-actions/setup-swift@v1
+
+      - name: Set up Xcode 16.2
+        uses: maxim-lobanov/setup-xcode@v1
         with:
-          swift-version: '6.0'
+          xcode-version: '16.2'
+
       - name: Run unit tests
         run: swift test --package-path TicTacToeCore

--- a/TicTacToeCore/Package.swift
+++ b/TicTacToeCore/Package.swift
@@ -23,5 +23,9 @@ let package = Package(
         .target(
             name: "TicTacToeCore"
         ),
+        .testTarget(
+            name: "TicTacToeCoreTests",
+            dependencies: ["TicTacToeCore"]
+        ),
     ]
 )

--- a/TicTacToeCore/Tests/TicTacToeCoreTests/GameBoardLogicTests.swift
+++ b/TicTacToeCore/Tests/TicTacToeCoreTests/GameBoardLogicTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import TicTacToeCore
+import Foundation
+
+@Suite("GameBoardLogic")
+struct GameBoardLogicTests {
+    @Test func checkGameStateDetectsRowWin() {
+        var board = GameBoardLogic()
+        board.place(at: [0,0], player: .first)
+        board.place(at: [0,1], player: .first)
+        board.place(at: [0,2], player: .first)
+
+        if case let .win(winner, positions) = board.checkGameState() {
+            #expect(winner == .first)
+            #expect(Set(positions) == Set([[0,0], [0,1], [0,2]]))
+        } else {
+            #expect(false, "Expected win")
+        }
+    }
+
+    @Test func checkGameStateDraw() {
+        var board = GameBoardLogic()
+        let pattern: [Player] = [
+            .first, .second, .first,
+            .first, .second, .second,
+            .second, .first, .first
+        ]
+        for i in 0..<9 {
+            board.place(at: [i/3, i%3], player: pattern[i])
+        }
+        #expect(board.checkGameState() == .draw)
+    }
+
+    @Test func minMaxFindsWinningMove() {
+        var board = GameBoardLogic()
+        board.place(at: [0,0], player: .first)
+        board.place(at: [1,1], player: .second)
+        board.place(at: [0,1], player: .first)
+        board.place(at: [1,0], player: .second)
+
+        let score = board.minMax(current: .first, players: (me: .first, opponent: .second))
+        #expect(score == 1)
+    }
+}

--- a/TicTacToeCore/Tests/TicTacToeCoreTests/GameStateTests.swift
+++ b/TicTacToeCore/Tests/TicTacToeCoreTests/GameStateTests.swift
@@ -1,0 +1,20 @@
+import Testing
+@testable import TicTacToeCore
+import Foundation
+
+@Suite("GameState")
+struct GameStateTests {
+    @Test func isGameFinished() {
+        #expect(!GameState.ongoing.isGameFinished)
+        #expect(GameState.draw.isGameFinished)
+        #expect(GameState.win(.first, positions: []).isGameFinished)
+    }
+
+    @Test func winnerAndPositions() {
+        let positions: [IndexPath] = [[0,0], [1,1], [2,2]]
+        let state = GameState.win(.second, positions: positions)
+        let result = state.winnerAndPositions
+        #expect(result.winner == .second)
+        #expect(result.positions == positions)
+    }
+}

--- a/TicTacToeCore/Tests/TicTacToeCoreTests/PlayerTests.swift
+++ b/TicTacToeCore/Tests/TicTacToeCoreTests/PlayerTests.swift
@@ -1,0 +1,18 @@
+import Testing
+@testable import TicTacToeCore
+
+@Suite("Player")
+struct PlayerTests {
+    @Test func opposite() {
+        #expect(Player.first.opposite == .second)
+        #expect(Player.second.opposite == .first)
+    }
+
+    @Test func toggle() {
+        var player: Player = .first
+        player.toggle()
+        #expect(player == .second)
+        player.toggle()
+        #expect(player == .first)
+    }
+}


### PR DESCRIPTION
## Summary
- replace XCTest with Swift Testing in core unit tests
- add CI workflow to run the new tests on macOS

## Testing
- `swift test --package-path TicTacToeCore` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_686a2bd7571c832c8baea84fd216dae6